### PR TITLE
Add an input watch

### DIFF
--- a/src/VoerroTagsInput.vue
+++ b/src/VoerroTagsInput.vue
@@ -164,6 +164,10 @@ export default {
     },
 
     watch: {
+        input() {
+            this.$emit('input-changed', this.input);
+        },
+        
         tags() {
             // Updating the hidden input
             this.hiddenInput = this.tags.join(',');


### PR DESCRIPTION
Could be used when you want to check if the length of a tag doenst exceed a certain limit.